### PR TITLE
fix: OOM Error owing to duplicated indices

### DIFF
--- a/memoria/memoria.py
+++ b/memoria/memoria.py
@@ -87,8 +87,10 @@ class Memoria:
         elif not self.enable_stm:
             reminded_indices = reminded_ltm_indices
 
+        reminded_indices = reminded_indices.unique(dim=1)
+
         # [BatchSize, RemindedMemoryLength, HiddenDim]
-        reminded_memories = self.engrams.select(reminded_indices).data
+        reminded_memories = self.engrams.select(reminded_indices).data.contiguous()
 
         return reminded_memories, reminded_indices
 


### PR DESCRIPTION
- There were duplicated indices which raise OOM becuase of attention memory usage