### PR TITLE
perf: Fix memory issue due to duplicated indices

### DIFF
--- a/memoria/memoria.py
+++ b/memoria/memoria.py
@@ -262,7 +262,7 @@ class Memoria:
             found_ltm_indices[:, depth + 1] = current_ltm_indices
             unreachable[index_0, current_ltm_indices] = True
 
-        return found_ltm_indices.view(batch_size, -1)
+        return found_ltm_indices.view(batch_size, -1).unique(dim=1)
 
     @torch.no_grad()
     def _select_final_ltms(self, working_memory: Engrams, found_longterm_memory_indices: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
- Fix memory wasting
- And it can harm for performance itself because it enable to select multiple non ltm, so make hard to select ltms