### PR TITLE
fix: Use unsqueeze to support older torch versions

### DIFF
--- a/memoria/engram.py
+++ b/memoria/engram.py
@@ -103,7 +103,9 @@ class Engrams:
                     dtype=torch.int32,
                     requires_grad=False,
                     device=data.device,
-                )[torch.newaxis, :].repeat(self.batch_size, 1)
+                )
+                .unsqueeze(0)
+                .repeat(self.batch_size, 1)
                 if not isinstance(engram_ids, torch.Tensor)
                 else engram_ids.detach().type(torch.int32)
             )

--- a/tests/test_engram.py
+++ b/tests/test_engram.py
@@ -47,11 +47,11 @@ def test_engram_ids():
 
     data = torch.randn(batch_size, memory_length, hidden_dim)
     engrams = Engrams(data, track_engram_id=True, engram_ids=0)
-    assert (engrams.engram_ids == torch.arange(0, memory_length)[torch.newaxis, :].repeat(batch_size, 1)).all()
+    assert (engrams.engram_ids == torch.arange(0, memory_length).unsqueeze(0).repeat(batch_size, 1)).all()
 
     data2 = torch.randn(batch_size, memory_length, hidden_dim)
     engrams2 = Engrams(data2, track_engram_id=True, engram_ids=14)
-    assert (engrams2.engram_ids == torch.arange(14, 14 + memory_length)[torch.newaxis, :].repeat(batch_size, 1)).all()
+    assert (engrams2.engram_ids == torch.arange(14, 14 + memory_length).unsqueeze(0).repeat(batch_size, 1)).all()
 
 
 def test_add():


### PR DESCRIPTION
- Use unsqueeze instead of torch.newaxis to support older torch versions